### PR TITLE
Pass payload primitive values as gh_<key> env vars

### DIFF
--- a/github-webhook.js
+++ b/github-webhook.js
@@ -160,6 +160,24 @@ function prefixStream (stream, prefix) {
   }))
 }
 
+function envFromPayload(payload, prefix, env) {
+  if (!env) env = {};
+  Object.keys(payload).forEach(function(k) {
+    var val = payload[k];
+    switch (typeof val) {
+      case 'boolean':
+      case 'number':
+      case 'string':
+      env[prefix + k] = val;
+      break;
+      case 'object':
+      if (val) envFromPayload(val, prefix + k + '_', env);
+      break;
+    }
+  });
+  return env;
+}
+
 
 function handleRules (logStream, rules, event) {
   function executeRule (rule) {
@@ -183,8 +201,10 @@ function handleRules (logStream, rules, event) {
 
     eventsDebug('Matched rule for %s', eventStr)
 
-    cp = spawn(exec.shift(), exec, { env: process.env })
-    
+    cp = spawn(exec.shift(), exec, {
+      env: Object.assign(envFromPayload(event.payload, 'gh_'), process.env)
+    });
+
     cp.on('error', function (err) {
       return eventsDebug('Error executing command [%s]: %s', rule.exec, err.message)
     })

--- a/github-webhook.js
+++ b/github-webhook.js
@@ -162,6 +162,8 @@ function prefixStream (stream, prefix) {
 
 function envFromPayload(payload, prefix, env) {
   if (!env) env = {};
+	if (payload.ref && payload.ref.startsWith('refs/heads/')) payload.branch = payload.ref.substring('refs/heads/'.length);
+	else payload.branch = null;
   Object.keys(payload).forEach(function(k) {
     var val = payload[k];
     switch (typeof val) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kapouer/github-webhook",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A flexible web server for reacting GitHub Webhooks",
   "main": "github-webhook.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-webhook",
+  "name": "@kapouer/github-webhook",
   "version": "1.1.3",
   "description": "A flexible web server for reacting GitHub Webhooks",
   "main": "github-webhook.js",
@@ -20,16 +20,16 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "bl": "~1.0.0",
-    "supertest": "~1.0.1",
-    "tape": "~4.0.0"
+    "bl": "^1.0.0",
+    "supertest": "^1.0.1",
+    "tape": "^4.0.0"
   },
   "dependencies": {
-    "debug": "~2.1.3",
-    "github-webhook-handler": "~0.4.0",
-    "matchme": "~2.0.1",
-    "minimist": "~1.1.1",
-    "split2": "~0.2.1",
-    "through2": "~2.0.0"
+    "debug": "^2.1.3",
+    "github-webhook-handler": "^0.7.1",
+    "matchme": "^2.0.1",
+    "minimist": "^1.1.1",
+    "split2": "^0.2.1",
+    "through2": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kapouer/github-webhook",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A flexible web server for reacting GitHub Webhooks",
   "main": "github-webhook.js",
   "scripts": {


### PR DESCRIPTION
So one can exec a string like (on a create event, for example):
`git fetch && git checkout ${gh_ref}`